### PR TITLE
docs: add english README & example wrangler.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/*
+wrangler.toml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Waline on Worker
 
+For international audience: [English Documentation](README_EN.md)
+
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
 
 一个运行在 **Cloudflare Workers** 上的 [Waline](https://waline.js.org/) 评论系统后端实现，使用 **D1 (SQLite)** 作为数据存储。实现了 Waline 的绝大多数功能。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,84 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
+# Waline on Worker
+
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
+
+A [Waline](https://waline.js.org/) comment system backend implementation running on **Cloudflare Workers**, utilizing **D1 (SQLite)** for data storage. It implements the vast majority of Waline's core features.
+
+---
+
+## Documentation
+
+[Detailed Documentation](docs/README.md)
+
+## Features
+
+- Fast
+- Secure
+- Markdown syntax support
+- Lightweight and easy to use
+- Free deployment
+- Fully compatible with the `@waline/client` frontend and `@waline/admin` dashboard
+
+
+|                    | Waline on Worker                                                       |
+| ------------------ | ---------------------------------------------------------------------- |
+| **Runtime**        | [Cloudflare Workers](https://workers.cloudflare.com/)                  |
+| **Database**       | [Cloudflare D1](https://developers.cloudflare.com/d1/) (SQLite)       |
+| **Framework**      | [Hono](https://hono.dev/)                                             |
+| **Language**       | TypeScript                                                             |
+
+> [!CAUTION]
+> **AI-Assisted Development Disclaimer**
+>
+> The code implementation of this project was primarily driven by AI. Although manual code reviews and testing have been performed as much as possible, **complete parity** with all behaviors of the original Waline Server **cannot be guaranteed**.
+>
+> Authentication and edge cases have been tested as thoroughly as possible, but **please assess the risks yourself before using it in a production environment.** Issues and Pull Requests are highly welcome to help improve the project.
+
+## Feature Status
+
+- [x] Comment CRUD (Threading, counters, recent comments)
+- [x] Page view (PV) statistics
+- [x] Comment reactions (Upvote / Downvote)
+- [x] Sticky comments (Pin to top)
+- [x] User registration / Login
+- [x] Comment management (Reviewing, deleting)
+- [x] Social login
+- [x] Two-Factor Authentication (2FA / TOTP)
+- [x] Markdown rendering + XSS protection
+- [x] Gravatar avatars
+- [x] UA parsing (Browser / Operating System)
+- [x] RSS subscription
+- [x] Data import/export (Compatible with the @waline/admin migration panel)
+- [x] LLM comment moderation (Embedded [waline-plugin-llm-reviewer-next](https://github.com/wuyilingwei/waline-plugin-llm-reviewer-next) design, supporting natural language safety policies)
+- [x] Comment default status control (Independent settings for anonymous and logged-in users)
+- [x] Admin dashboard (@waline/admin CDN + Worker settings page)
+- [x] IP rate limiting (IPQPS) can be directly configured via Cloudflare security rules
+- [x] Additional management panel to set default frontend versions, control default comment statuses, configure LLM moderation strategies, and more
+- [ ] GitHub OAuth login
+- [ ] Email notifications (SMTP)
+- [ ] Webhook notifications
+
+> [!NOTE]
+> The Akismet anti-spam function is handled via the built-in LLM comment moderation feature—connect any OpenAI-compatible LLM API and set moderation rules using natural language to intelligently audit comments.
+
+## Quick Start
+
+```bash
+git clone https://github.com/wuyilingwei/Waline_On_Worker.git
+cd Waline_On_Worker
+pnpm install
+
+# Create D1 database and edit wrangler.toml
+npx wrangler d1 create waline-db
+pnpm run db:init
+npx wrangler secret put JWT_SECRET
+pnpm run deploy
+```
+
+Please refer to the [documentation](docs/README.md) for detailed deployment steps and configuration instructions.
+
+## License
+
+[GPL-3.0](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Waline on Worker 详细文档
 
+For international audience: [English Documentation](README_EN.md)
+
 ## 快速开始
 
 ### 前提条件

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,0 +1,301 @@
+# Waline on Worker - Detailed Documentation
+
+## Quick Start
+
+### Prerequisites
+
+* Node.js >= 18
+* pnpm
+* Cloudflare account
+* Wrangler CLI installed and logged in
+
+### One-Click Deployment
+
+```bash
+# Clone the repository
+git clone https://github.com/wuyilingwei/Waline_On_Worker.git
+cd Waline_On_Worker
+
+# Run deployment script
+
+# Linux / macOS
+chmod +x deploy.sh
+./deploy.sh
+
+# Windows (PowerShell)
+.\deploy.ps1
+```
+
+### Manual Deployment
+
+```bash
+# 1. Install dependencies
+pnpm install
+
+# 2. Create a D1 database
+npx wrangler d1 create waline-db
+
+# 3. Edit wrangler.toml and fill in the database_id
+# returned from the previous step
+
+# 4. Initialize the database schema
+pnpm run db:init
+
+# 5. Set JWT secret
+npx wrangler secret put JWT_SECRET
+# Enter a random string as the secret
+
+# 6. Deploy
+pnpm run deploy
+```
+
+### Local Development
+
+```bash
+# Initialize local database
+pnpm run db:init:local
+
+# Start development server
+pnpm run dev
+```
+
+---
+
+# API Endpoints
+
+## Comments
+
+| Method | Path                           | Description                   | Authentication |
+| ------ | ------------------------------ | ----------------------------- | -------------- |
+| GET    | `/api/comment?path=`           | Get comment list (threaded)   | None           |
+| GET    | `/api/comment?type=recent`     | Recent comments               | None           |
+| GET    | `/api/comment?type=count&url=` | Comment count                 | None           |
+| GET    | `/api/comment?type=list`       | Admin comment list            | Admin          |
+| GET    | `/api/comment/rss`             | RSS feed                      | None           |
+| POST   | `/api/comment`                 | Create comment                | None           |
+| PUT    | `/api/comment/:id`             | Update comment / like comment | Admin / Like   |
+| DELETE | `/api/comment/:id`             | Delete comment (cascading)    | Admin          |
+
+## Articles
+
+| Method | Path                | Description                     | Authentication |
+| ------ | ------------------- | ------------------------------- | -------------- |
+| GET    | `/api/article?url=` | Get page views                  | None           |
+| POST   | `/api/article`      | Increase page views / reactions | None           |
+
+## Users
+
+| Method | Path            | Description        | Authentication |
+| ------ | --------------- | ------------------ | -------------- |
+| POST   | `/api/user`     | Register user      | None           |
+| GET    | `/api/user`     | User list          | None / Admin   |
+| PUT    | `/api/user/:id` | Update user        | Self / Admin   |
+| DELETE | `/api/user/:id` | Delete or ban user | Admin          |
+
+## Authentication
+
+| Method | Path             | Description               | Authentication |
+| ------ | ---------------- | ------------------------- | -------------- |
+| POST   | `/api/token`     | Login                     | None           |
+| GET    | `/api/token`     | Get current user info     | Bearer Token   |
+| DELETE | `/api/token`     | Logout                    | None           |
+| POST   | `/api/token/2fa` | Two-factor authentication | Bearer Token   |
+
+## OAuth
+
+| Method | Path                         | Description       | Authentication |
+| ------ | ---------------------------- | ----------------- | -------------- |
+| GET    | `/api/oauth?type=<provider>` | Start OAuth login | None           |
+
+Supported OAuth providers (`type` parameter):
+
+* github
+* twitter
+* facebook
+* weibo
+* qq
+
+OAuth login is handled through an external OAuth proxy service (default: `https://oauth.lithub.cc`), which can be customized via the `OAUTH_URL` environment variable.
+
+## Data Management
+
+| Method | Path                       | Description                          | Authentication |
+| ------ | -------------------------- | ------------------------------------ | -------------- |
+| GET    | `/api/db`                  | Export all data (Waline JSON format) | Admin          |
+| POST   | `/api/db?table=`           | Import a single record               | Admin          |
+| PUT    | `/api/db?table=&objectId=` | Update imported data                 | Admin          |
+| DELETE | `/api/db?table=`           | Clear specified table                | Admin          |
+
+## Settings
+
+| Method | Path            | Description     | Authentication |
+| ------ | --------------- | --------------- | -------------- |
+| GET    | `/api/settings` | Get settings    | Admin          |
+| PUT    | `/api/settings` | Update settings | Admin          |
+
+## Admin Panel
+
+| Path                 | Description                 |
+| -------------------- | --------------------------- |
+| `/ui`                | @waline/admin dashboard     |
+| `/ui/worker-setting` | Worker custom settings page |
+
+> The first registered user automatically becomes an administrator.
+
+---
+
+# Data Import & Export
+
+This project provides a `/api/db` endpoint fully compatible with the `@waline/admin` dashboard, supporting standard Waline JSON import/export.
+
+## Importing & Exporting via Admin Panel
+
+1. Visit `/ui` and log in as an administrator.
+2. Open the **Import/Export** page.
+3. **Export:** Click Export to download `waline.json`.
+4. **Import:** Select a previously exported `waline.json` file and import it.
+
+## Importing via Wrangler CLI
+
+For large datasets, direct D1 database operations are recommended:
+
+```bash
+# Export to SQL
+npx wrangler d1 export <database-name> --remote --output=backup.sql
+
+# Import from SQL
+npx wrangler d1 execute <database-name> --remote --file=backup.sql
+```
+
+### Warning: Large Data Imports
+
+When importing hundreds of records or more through the admin panel, Cloudflare Workers request timeouts or D1 concurrency limits may cause **500 errors**.
+
+Recommended solutions:
+
+1. **Chunked imports** – Split JSON into batches of around 500 records.
+2. **Use Wrangler CLI** – More reliable for large migrations.
+3. **Use migration scripts** – See `migrate.ts` or `migrate-d1.ts`.
+
+---
+
+# Configuration
+
+## Environment Variables (`wrangler.toml [vars]`)
+
+| Variable       | Description                       | Default |
+| -------------- | --------------------------------- | ------- |
+| SITE_NAME      | Site name                         | Waline  |
+| SITE_URL       | Site URL                          | None    |
+| SECURE_DOMAINS | Allowed domains (comma-separated) | None    |
+
+## Secrets (via `wrangler secret put`)
+
+| Secret     | Description        | Required |
+| ---------- | ------------------ | -------- |
+| JWT_SECRET | JWT signing secret | Yes      |
+
+## Worker Settings (configured via `/ui/worker-setting`)
+
+| Setting                     | Description                                                   | Default  |
+| --------------------------- | ------------------------------------------------------------- | -------- |
+| waline_client_version       | @waline/client CDN version                                    | None     |
+| comment_default_status      | Default status for anonymous comments (approved/waiting/spam) | approved |
+| user_comment_default_status | Default status for logged-in user comments                    | approved |
+| worker_display              | Show Worker extension menu in admin panel                     | None     |
+| llm_mode                    | LLM moderation mode (off/anonymous/all)                       | off      |
+| llm_skip_admin              | Skip LLM moderation for admin comments                        | None     |
+| llm_endpoint                | LLM API endpoint URL                                          | None     |
+| llm_api_key                 | LLM API key                                                   | None     |
+| llm_model                   | LLM model name                                                | None     |
+| llm_prompt                  | LLM moderation prompt                                         | None     |
+
+## OAuth Configuration
+
+| Variable  | Description             | Default                   |
+| --------- | ----------------------- | ------------------------- |
+| OAUTH_URL | OAuth proxy service URL | `https://oauth.lithub.cc` |
+
+OAuth login uses an external proxy service to handle Client IDs and Secrets, so platform credentials do not need to be configured inside the Worker.
+
+Supported providers:
+
+* GitHub
+* Twitter
+* Facebook
+* Weibo
+* QQ
+
+---
+
+# Front-End Integration
+
+Use `@waline/client` in your website:
+
+```html
+<script src="https://unpkg.com/@waline/client@v3/dist/waline.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css" />
+
+<div id="waline"></div>
+
+<script>
+  Waline.init({
+    el: '#waline',
+    serverURL: 'https://your-worker-name.your-subdomain.workers.dev',
+  });
+</script>
+```
+
+---
+
+# Project Structure
+
+```text
+src/
+├── index.ts               # Workers entry (Hono + CORS + auth + version)
+├── env.ts                 # Type definitions
+├── router/
+│   ├── comment.ts         # Comment CRUD + LLM moderation
+│   ├── article.ts         # Page views/reaction counters
+│   ├── user.ts            # User management
+│   ├── token.ts           # JWT login + 2FA
+│   ├── oauth.ts           # OAuth login
+│   │                      # (GitHub/Twitter/Facebook/Google/Weibo/QQ)
+│   ├── settings.ts        # Worker settings management
+│   │                      # (API keys returned masked)
+│   └── db.ts              # Data import/export
+├── middleware/
+│   └── auth.ts            # JWT authentication middleware
+├── ui/
+│   ├── admin-panel.ts     # @waline/admin dashboard
+│   ├── custom-admin.ts    # Custom Worker settings page
+│   └── waline-page.ts     # Waline comments page
+└── utils/
+    ├── password.ts        # PBKDF2 password hashing
+    ├── avatar.ts          # Gravatar avatars
+    ├── ua.ts              # User-Agent parsing
+    ├── markdown.ts        # Markdown rendering
+    ├── llm-review.ts      # LLM comment moderation
+    └── totp.ts            # TOTP two-factor authentication
+
+schema.sql                 # D1 database schema
+migrate.ts                 # LeanCloud migration
+migrate-d1.ts              # D1-to-D1 migration
+wrangler.toml              # Workers configuration
+deploy.sh / deploy.ps1     # Deployment scripts
+```
+
+### Summary
+
+This project is a Cloudflare Workers + D1 implementation of **Waline**, providing:
+
+* Comment system
+* Admin dashboard
+* JWT authentication
+* Two-factor authentication (2FA)
+* OAuth login
+* Data import/export compatibility with Waline
+* LLM-powered comment moderation
+* Cloudflare D1 storage
+* One-click deployment support
+* Full compatibility with `@waline/client` and `@waline/admin`

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -1,0 +1,18 @@
+#:schema node_modules/wrangler/config-schema.json
+
+# your cloudflare worker name; create an empty/hello-world worker
+# from cloudflare dashboard
+name = "waline-on-worker"
+main = "src/index.ts"
+compatibility_date = "2026-06-03" # could be current-date
+
+# Environment Variables (Public configurations)
+[vars]
+# Optional: Restrict CORS access to specific domains (comma-separated, no http://)
+# SECURE_DOMAINS = "yourdomain.com,localhost:3000"
+
+# Cloudflare D1 Database Binding
+[[d1_databases]]
+binding = "DB" # Do not change this binding name
+database_name = "YOUR_DATABASE_NAME"
+database_id = "YOUR_CLOUDFLARE_D1_DATABASE_ID"


### PR DESCRIPTION
I got interested in this project, as I was developing my own theme, and was on hunt for comment system which was minimal, fast and beautiful at the same time. I landed on walinejs, but my site was in cloudflare ecosystem, and i didn't want another dependency of using vercel/ or anyothers, and thereby spent approx 2 hours and reached on your repo. Thanks for this work, I appreciate it, and I look forward to contribute and improve it. 

This PR adds English support for both README files (project, and docs/) for wide audience reach, along with minimal deployment configuration file `wrangler.toml` needed for the setup. Also added a .gitignore file. 

<img width="1887" height="737" alt="image" src="https://github.com/user-attachments/assets/1e22c6c4-fdef-4df4-be61-a35057b304af" />
