### PR TITLE
fix: accept url params and comma-joined paths in count & article endpoints

### DIFF
--- a/src/router/article.ts
+++ b/src/router/article.ts
@@ -31,13 +31,29 @@ const VALID_FIELDS = new Set([
  *   - multiple paths: [{[type]: count}, …]
  */
 articleRoutes.get("/", async (c) => {
-	const paths = c.req.queries("path") || c.req.queries("path[]") || [];
+	// Official @waline/client fetches counters as
+	// `article?path=<path1>,<path2>&type=time,reaction0` (comma-joined single
+	// params), while some embeds use `path[]`/`type[]`. Split values on commas
+	// like the official server does.
+	const paths = [
+		...(c.req.queries("path") || []),
+		...(c.req.queries("path[]") || []),
+	]
+		.flatMap((p: string) => p.split(","))
+		.filter(Boolean);
 	if (paths.length === 0) {
 		return c.json({ errno: 0, errmsg: "", data: 0 });
 	}
 
-	const types = c.req.queries("type") || c.req.queries("type[]") || ["time"];
-	const validTypes = types.filter((t) => VALID_FIELDS.has(t));
+	const types = [
+		...(c.req.queries("type") || []),
+		...(c.req.queries("type[]") || []),
+	]
+		.flatMap((t: string) => t.split(","))
+		.filter(Boolean);
+	const validTypes = (types.length > 0 ? types : ["time"]).filter((t: string) =>
+		VALID_FIELDS.has(t),
+	);
 	if (validTypes.length === 0) {
 		return c.json({ errno: 0, errmsg: "", data: paths.map(() => ({})) });
 	}

--- a/src/router/comment.ts
+++ b/src/router/comment.ts
@@ -549,7 +549,18 @@ async function getRecentComments(c: any) {
 }
 
 async function getCommentCount(c: any) {
-	const paths = c.req.queries("path") || c.req.queries("path[]") || [];
+	// Official @waline/client fetches comment counts as
+	// `comment?type=count&url=<path1>,<path2>` (single `url` param, comma-joined),
+	// while some embeds/admin tools use `path`/`path[]`. Collect every accepted
+	// param name, then split values on commas like the official server does.
+	const paths = [
+		...(c.req.queries("url") || []),
+		...(c.req.queries("url[]") || []),
+		...(c.req.queries("path") || []),
+		...(c.req.queries("path[]") || []),
+	]
+		.flatMap((p: string) => p.split(","))
+		.filter(Boolean);
 	if (paths.length === 0) {
 		return c.json({ errno: 0, errmsg: "", data: 0 });
 	}


### PR DESCRIPTION
## 问题

官方 `@waline/client` 前端请求评论计数和浏览量时，参数格式与本项目后端的读取逻辑不匹配，导致部署后前端计数始终为 0。

官方 client 的实际请求（已从 `@waline/client@v3` 源码确认）：

- 评论计数：`GET /api/comment?type=count&url=<path1>,<path2>` —— 单个 `url` 参数、多路径逗号拼接
- 浏览量：`GET /api/article?path=<path1>,<path2>&type=time,reaction0` —— `path` 和 `type` 同样逗号拼接

而后端 `getCommentCount` 只读取 `path`/`path[]` 参数，`article` GET 路由也从未按逗号拆分，造成三个问题：

1. 官方 client 传入的 `url` 参数被完全忽略，评论计数恒为 0
2. 多路径计数请求把 `"/a/,/b/"` 当成一个整体 URL 去查询，返回错误结果
3. 多字段的浏览量请求中 `type="time,reaction0"` 无法通过 `VALID_FIELDS.has()` 校验，所有字段被丢弃，返回空对象

## 修复

- `getCommentCount` 现在接受 `url` / `url[]` / `path` / `path[]` 四种参数
- 两个端点都按逗号拆分参数值，与官方 Waline server 的行为一致（官方 server 对 `url` 同样执行 `split(',')` 后 flat）
- `article` 的 `type` 参数同样支持逗号拆分，未传时保持默认 `time`

## 验证

本地 `wrangler dev` + D1 实测以下请求全部返回正确结果：

| 请求 | 结果 |
|---|---|
| `comment?type=count&url=/a/` | `[1]` |
| `comment?type=count&url=/a/,/b/` | `[1,1]` |
| `comment?type=count&url[]=/a/&url[]=/b/` | `[1,1]` |
| `comment?type=count&path=/a/` | `[1]` |
| `article?path=/a/&type=time` | `[{"time":7}]` |
| `article?path=/a/,/b/&type=time,reaction0` | `[{"time":7,"reaction0":0},{"time":3,"reaction0":0}]` |
| `article?path=/a/`（无 type） | `[{"time":7}]` |

已在本人的生产环境（`@waline/client` v3 + 此 Worker 后端）验证：修复前首页/留言板计数显示 0，修复后正确显示 42。